### PR TITLE
Fixes tests

### DIFF
--- a/lib/Bio/MLST/Download/Databases.pm
+++ b/lib/Bio/MLST/Download/Databases.pm
@@ -30,7 +30,7 @@ use Parallel::ForkManager;
 has 'databases_attributes' => ( is => 'ro', isa => 'HashRef', required => 1 );
 has 'base_directory'       => ( is => 'ro', isa => 'Str',     required => 1 );
 
-has 'parallel_processes'   => ( is => 'ro', isa => 'Int',     default => 4 );
+has 'parallel_processes'   => ( is => 'ro', isa => 'Int',     default => 1 );
 
 has '_species_to_exclude'  => ( is => 'ro', isa => 'Str',     default => 'Pediococcus' );
 

--- a/lib/Bio/MLST/Download/Databases.pm
+++ b/lib/Bio/MLST/Download/Databases.pm
@@ -30,7 +30,7 @@ use Parallel::ForkManager;
 has 'databases_attributes' => ( is => 'ro', isa => 'HashRef', required => 1 );
 has 'base_directory'       => ( is => 'ro', isa => 'Str',     required => 1 );
 
-has 'parallel_processes'   => ( is => 'ro', isa => 'Int',     default => 1 );
+has 'parallel_processes'   => ( is => 'ro', isa => 'Int',     default => 0 );
 
 has '_species_to_exclude'  => ( is => 'ro', isa => 'Str',     default => 'Pediococcus' );
 

--- a/lib/Bio/MLST/Download/Databases.pm
+++ b/lib/Bio/MLST/Download/Databases.pm
@@ -42,7 +42,10 @@ sub update
   {
     $pm->start and next; # do the fork
     my $species_to_exclude = $self->_species_to_exclude;
-    next if($species =~ /$species_to_exclude/i);
+    if($species =~ /$species_to_exclude/i) {
+      $pm->finish;  # do the exit in the child process
+      next;
+    }
     my $database = Bio::MLST::Download::Database->new(
       species => $species,
       database_attributes => $self->databases_attributes->{$species},

--- a/t/SequenceTypes/SearchForFiles.t
+++ b/t/SequenceTypes/SearchForFiles.t
@@ -26,7 +26,9 @@ sub species_name_regex
     species_name => $regex,
     base_directory => 't/data'
   )),"initialise searching for files with $regex");
-  is_deeply(['t/data/Escherichia_coli_1/alleles/adk.tfa', 't/data/Escherichia_coli_1/alleles/purA.tfa','t/data/Escherichia_coli_1/alleles/recA.tfa'],$search_results->allele_filenames(),"allele filenames for $regex");
+  my @results = sort @{$search_results->allele_filenames()};
+  my @expected_results = ('t/data/Escherichia_coli_1/alleles/adk.tfa', 't/data/Escherichia_coli_1/alleles/purA.tfa','t/data/Escherichia_coli_1/alleles/recA.tfa');
+  is_deeply(\@results, \@expected_results, "allele filenames for $regex");
   is('t/data/Escherichia_coli_1/profiles/escherichia_coli.txt', $search_results->profiles_filename(),"profiles filename for $regex");
   
 }


### PR DESCRIPTION
Fixes:
- test created phylip files but listed the sequences in a different order than expected.  This shouldn't fail the test so I sort the results before comparing them
- likewise, when it searched for some files, they were returned in a different order than expected, so I fixed it
- finally there was a problem that threads weren't being killed during a test and it was causing the test to return more than once.

I've added a String::Util dependency so that I can remove whitespace during the first fix.  I'm not sure if I need to record this somewhere or if dzil just picks it up auto-magically.

I'm also not sure what I need to do to bump the version / release / publish this?  Given that it wouldn't install for me without a --force because of the failing tests, it would be nice to share this with others.