### PR TITLE
Ticket 442599 Fix database updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ MYMETA.yml
 nytprof.out
 pm_to_blib
 extras/
+*.swp

--- a/lib/Bio/MLST/Check.pm
+++ b/lib/Bio/MLST/Check.pm
@@ -86,12 +86,13 @@ sub _generate_spreadsheet_rows
       my ($pid, $exit_code, $ident, $exit_signal, $core_dump, $data_structure_reference) = @_;
       # retrieve data structure from child
       if (defined($data_structure_reference)) {  # children are not forced to send anything
-        push(@{$self->_spreadsheet_header}, $data_structure_reference->[0]);
-        push(@{$self->_spreadsheet_allele_numbers_rows}, $data_structure_reference->[1]);
-        push(@{$self->_spreadsheet_genomic_rows}, $data_structure_reference->[2]);
+        my ($header_row, $allele_numbers_row, $genomic_row, $concat_name, $concat_sequence) = @{$data_structure_reference};
+        push(@{$self->_spreadsheet_header}, $header_row);
+        push(@{$self->_spreadsheet_allele_numbers_rows}, $allele_numbers_row);
+        push(@{$self->_spreadsheet_genomic_rows}, $genomic_row);
         
-        push(@{$self->_concat_names}, $data_structure_reference->[3]);
-        push(@{$self->_concat_sequences}, $data_structure_reference->[4]);
+        push(@{$self->_concat_names}, $concat_name);
+        push(@{$self->_concat_sequences}, $concat_sequence);
 
       } else {  # problems occuring during storage or retrieval will throw a warning
         print qq|No message received from child process $pid!\n|;

--- a/lib/Bio/MLST/Download/Databases.pm
+++ b/lib/Bio/MLST/Download/Databases.pm
@@ -59,7 +59,7 @@ sub update {
    my $production_directory = join('/',($self->base_directory));
    $self->_update_all_from_staging($staging_directory,
                                    $production_directory);
-   #rmtree($staging_directory);
+   rmtree($staging_directory);
    1;
 }
 

--- a/lib/Bio/MLST/Download/Databases.pm
+++ b/lib/Bio/MLST/Download/Databases.pm
@@ -27,6 +27,11 @@ use Moose;
 use Bio::MLST::Download::Database;
 use Parallel::ForkManager;
 
+use Try::Tiny;
+use File::Copy qw(move);
+use File::Path qw(make_path rmtree);
+use POSIX qw(strftime);
+
 has 'databases_attributes' => ( is => 'ro', isa => 'HashRef', required => 1 );
 has 'base_directory'       => ( is => 'ro', isa => 'Str',     required => 1 );
 
@@ -34,27 +39,80 @@ has 'parallel_processes'   => ( is => 'ro', isa => 'Int',     default => 0 );
 
 has '_species_to_exclude'  => ( is => 'ro', isa => 'Str',     default => 'Pediococcus' );
 
-sub update
+sub update {
+   my($self) = @_;
+   my $paths_to_database_updates = $self->databases_attributes;
+   my $species_to_exclude = $self->_species_to_exclude;
+   my $temp_folder = strftime "temp_%Y%m%d%H%M%S", localtime; # e.g. temp_20150402102622
+   my $staging_directory = join('/', ($self->base_directory, 'staging', $temp_folder));
+   try {
+     $self->_download_to_staging($species_to_exclude,
+                                 $paths_to_database_updates,
+                                 $staging_directory);
+   } catch {
+     my $original_error = $_ || 'Unknown error';
+     die "Sorry, there was a problem updating the database.  ",
+         "Some of the updates have been downloaded to $staging_directory ",
+         "but this is likely to be incomplete\n",
+         "The original message was as follows:\n$original_error";
+   };
+   my $production_directory = join('/',($self->base_directory));
+   $self->_update_all_from_staging($staging_directory,
+                                   $production_directory);
+   #rmtree($staging_directory);
+   1;
+}
+
+sub _download_to_staging
 {
-  my($self) = @_;
-  my $pm = new Parallel::ForkManager($self->parallel_processes); 
-  for my $species (keys %{$self->databases_attributes})
+  my($self, $species_to_exclude, $paths_to_downloads, $staging_directory) = @_;
+  my $pm = new Parallel::ForkManager($self->parallel_processes);
+
+  for my $species (keys %{$paths_to_downloads})
   {
     $pm->start and next; # do the fork
-    my $species_to_exclude = $self->_species_to_exclude;
     if($species =~ /$species_to_exclude/i) {
-      $pm->finish;  # do the exit in the child process
+      $pm->finish; # exit child process
       next;
     }
+
     my $database = Bio::MLST::Download::Database->new(
       species => $species,
-      database_attributes => $self->databases_attributes->{$species},
-      base_directory      => join('/',($self->base_directory))
+      database_attributes => $paths_to_downloads->{$species},
+      base_directory      => $staging_directory
     );
     $database->update();
-    $pm->finish; # do the exit in the child process
+    $pm->finish; # exit the child process
   }
   $pm->wait_all_children;
+  1;
+}
+
+sub _get_sub_directories
+{
+  my($self, $parent_folder) = @_;
+  return [] if (! -d $parent_folder);
+  opendir(my $FOLDER_HANDLE, $parent_folder);
+  my @folder_contents = readdir($FOLDER_HANDLE);
+  my @real_contents = grep { ! /^\.$/ and ! /^\.\.$/ } @folder_contents; # Remove '.' and '..' directories
+  my @child_directories = grep { -d "$parent_folder/$_" } @real_contents;
+  return \@child_directories;
+}
+
+sub _update_all_from_staging
+{
+  my($self, $staging_directory, $production_directory) = @_;
+
+  my $species_directories = $self->_get_sub_directories($staging_directory);
+
+  foreach my $species_directory (@{$species_directories}){
+    my $species_staging_path = join("/", ($staging_directory, $species_directory));
+    my $species_production_path = join("/", ($production_directory, $species_directory));
+    if (-d $species_staging_path ) {
+      rmtree($species_production_path) if ( -d $species_production_path );
+      move($species_staging_path, $species_production_path);
+    }
+  }
   1;
 }
 

--- a/lib/Bio/MLST/Download/Downloadable.pm
+++ b/lib/Bio/MLST/Download/Downloadable.pm
@@ -33,7 +33,8 @@ sub _download_file
   }
   else
   {
-    getstore($filename, join('/',($destination_directory,$self->_get_filename_from_url($filename))));
+    my $status = getstore($filename, join('/',($destination_directory,$self->_get_filename_from_url($filename))));
+    die "Something went wrong, got a $status status code" if is_error($status);
   }
   1;
 }

--- a/t/CDC/Convert.t
+++ b/t/CDC/Convert.t
@@ -31,7 +31,7 @@ compare_files('t/data/Streptococcus_pyogenes_emmST/profiles/Streptococcus_pyogen
 
 
 # Check the the converted files can be used
-my $tmpdirectory_obj = File::Temp->newdir( CLEANUP => 0, DIR => getcwd );
+my $tmpdirectory_obj = File::Temp->newdir( CLEANUP => 1, DIR => getcwd );
 my $tmpdirectory = $tmpdirectory_obj->dirname();
 
 ok((my $check_converted_files_obj = Bio::MLST::Check->new(

--- a/t/Download/Database_fails.t
+++ b/t/Download/Database_fails.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Temp;
+use Test::MockModule;
+use Test::Exception;
+use HTTP::Status;
+use File::Touch qw(touch);
+use File::Path qw(make_path);
+
+BEGIN { unshift(@INC, './lib') }
+BEGIN {
+    use Test::Most;
+}
+
+my $lwp = new Test::MockModule('LWP::Simple');
+$lwp->mock(getstore => sub { return RC_NOT_FOUND });
+$lwp->mock(is_success => sub { return 0 });
+use_ok('Bio::MLST::Download::Database');
+use_ok('Bio::MLST::DatabaseSettings');
+use_ok('Bio::MLST::Download::Databases');
+
+my $destination_directory_obj = File::Temp->newdir(CLEANUP =>1);
+my $destination_directory = $destination_directory_obj->dirname();
+
+# Create fake database contents to check if they are overwritten by update
+make_path($destination_directory.'/Bordetella_spp/profiles/');
+touch($destination_directory.'/Bordetella_spp/profiles/file_to_be_kept.txt');
+
+my $database = Bio::MLST::Download::Database->new(
+  database_attributes => { 
+      alleles => ['t/data/abc.fas','t/data/efg.fas'], 
+      profiles => 't/data/bordetella.txt'
+    },
+  base_directory => $destination_directory,
+  species => "ABC EFG#1"
+  );
+
+dies_ok( sub { $database->_download_file("http://www.definitlynotactuallyawebsiteexample.com", "/tmp/not/actually/a/path") }, "Mock downloading a missing file - IGNORE Prototype warnings above and below");
+
+my $database_settings = Bio::MLST::DatabaseSettings->new(filename => 't/data/missing_web_database.xml')->settings;
+my $databases = Bio::MLST::Download::Databases->new(
+  databases_attributes => $database_settings,
+  base_directory  => $destination_directory
+);
+dies_ok( sub { $databases->update() },'Fails gracefully if there is a problem downloading the new database');
+
+ok((-e $destination_directory.'/Bordetella_spp/profiles/file_to_be_kept.txt'), "Did not overwrite existing data");
+
+done_testing();

--- a/t/Download/Database_succeeds.t
+++ b/t/Download/Database_succeeds.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Temp;
+use Test::MockModule;
+use Test::Exception;
+use HTTP::Status;
+use File::Touch qw(touch);
+use File::Path qw(make_path);
+
+BEGIN { unshift(@INC, './lib') }
+BEGIN {
+    use Test::Most;
+}
+
+my $lwp = new Test::MockModule('LWP::Simple');
+$lwp->mock(getstore => sub { return RC_OK });
+$lwp->mock(is_success => sub { return 0 });
+use_ok('Bio::MLST::Download::Database');
+use_ok('Bio::MLST::DatabaseSettings');
+use_ok('Bio::MLST::Download::Databases');
+
+my $destination_directory_obj = File::Temp->newdir(CLEANUP =>1);
+my $destination_directory = $destination_directory_obj->dirname();
+
+# Create fake database contents to check if they are overwritten by update
+make_path($destination_directory.'/Bordetella_spp/profiles/');
+touch($destination_directory.'/Bordetella_spp/profiles/file_to_be_kept.txt');
+
+my $database = Bio::MLST::Download::Database->new(
+  database_attributes => { 
+      alleles => ['t/data/abc.fas','t/data/efg.fas'], 
+      profiles => 't/data/bordetella.txt'
+    },
+  base_directory => $destination_directory,
+  species => "ABC EFG#1"
+  );
+
+ok($database->_download_file("http://www.definitlynotactuallyawebsiteexample.com", "/tmp/not/actually/a/path"), "Mock downloading a file - IGNORE Prototype warnings above and below");
+
+my $database_settings = Bio::MLST::DatabaseSettings->new(filename => 't/data/missing_web_database.xml')->settings;
+my $databases = Bio::MLST::Download::Databases->new(
+  databases_attributes => $database_settings,
+  base_directory  => $destination_directory
+);
+ok($databases->update(),'Carries on if it thinks that it has downloaded everything successfully');
+
+ok((! -e $destination_directory.'/Bordetella_spp/profiles/file_to_be_kept.txt'), "Overwrites the existing contents of the database");
+
+done_testing();

--- a/t/Download/Databases.t
+++ b/t/Download/Databases.t
@@ -43,7 +43,7 @@ ok((my $databases2 = Bio::MLST::Download::Databases->new(
 )), 'initalise setting up databases');
 ok($databases2->update(),'download databases (nothing should happen)');
 
-ok((! (-e $destination_directory.'/Pediococcus_pentosaceus/alleles/gyrB.tfa')),'nothing should be downloaded' );
+ok((! (-e $destination_directory2.'/Pediococcus_pentosaceus/alleles/gyrB.tfa')),'nothing should be downloaded' );
 
 done_testing();
 

--- a/t/Download/Databases.t
+++ b/t/Download/Databases.t
@@ -3,6 +3,9 @@ use strict;
 use warnings;
 use File::Temp;
 
+use File::Touch qw(touch);
+use File::Path qw(make_path);
+
 BEGIN { unshift(@INC, './lib') }
 BEGIN {
     use Test::Most;
@@ -12,6 +15,12 @@ BEGIN {
 
 my $destination_directory_obj = File::Temp->newdir(CLEANUP =>1);
 my $destination_directory = $destination_directory_obj->dirname();
+
+# Create fake database contents to check if they are overwritten by update
+make_path($destination_directory.'/Bordetella_spp/profiles/');
+touch($destination_directory.'/Bordetella_spp/profiles/file_to_be_deleted.txt');
+make_path($destination_directory.'/Fake_species/profiles/');
+touch($destination_directory.'/Fake_species/profiles/file_to_be_kept.txt');
 
 ok((my $database_settings = Bio::MLST::DatabaseSettings->new(filename => 't/data/overall_databases.xml')->settings),"get overall list of databases");
 
@@ -30,6 +39,10 @@ ok((-e $destination_directory.'/Bordetella_spp/profiles/bordetella.txt'));
 ok((-e $destination_directory.'/Homo_sapiens_1/alleles/ddd.fas'));
 ok((-e $destination_directory.'/Homo_sapiens_1/alleles/eee.fas'));
 ok((-e $destination_directory.'/Homo_sapiens_1/profiles/homo_sapiens.txt'));
+
+# Check if the fake database contents are overwritten
+ok((! -e $destination_directory.'/Bordetella_spp/profiles/file_to_be_deleted.txt'), "species is successfully overwritten");
+ok((-e $destination_directory.'/Fake_species/profiles/file_to_be_kept.txt'), "species is not overwritten");
 
 
 my $destination_directory_obj2 = File::Temp->newdir(CLEANUP =>1);

--- a/t/data/missing_web_database.xml
+++ b/t/data/missing_web_database.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<data>
+<species>
+Bordetella spp.
+<mlst>
+<database>
+<url>http://pubmlst.org/bordetella/</url>
+<retrieved>2012-07-23</retrieved>
+<profiles>
+<count>58</count>
+<url>"http://www.definitlynotactuallyawebsiteexample.com/profile"</url>
+</profiles>
+<loci>
+<locus>
+allele_1
+<url>
+http://www.definitlynotactuallyawebsiteexample.com/allele_1
+</url>
+</locus>
+</loci>
+</database>
+</mlst>
+</species>
+</data>


### PR DESCRIPTION
If the alleles changed then the database used to get corrupted.  This was because it merged the old and the new alleles and got confused.  This PR downloads the new data to a staging area.  If that went smoothly it then overwrites all of the old data with the new data.

Only updated species are affected.  If there is a problem downloading the new data, none of the species are updated.