### PR TITLE
Ticket 463083 Update versioning

### DIFF
--- a/bin/download_fasta_database
+++ b/bin/download_fasta_database
@@ -24,14 +24,17 @@ use Moose;
 use Getopt::Long;
 use Bio::MLST::CDC::Convert;
 
-my ($config_file, $base_directory,$url, $species,$gene_name, $help);
+my ($config_file, $base_directory,$url, $species,$gene_name, $help, $version);
 
 GetOptions ('u|url=s'            => \$url,
             'b|base_directory=s' => \$base_directory,
             's|species=s',       => \$species,
             'g|gene_name=s',     => \$gene_name,
             'h|help'             => \$help,
+            'v|version'          => \$version,
 );
+
+(! $version ) or die "$0 version " . Bio::MLST::Bin::Download->VERSION . "\n";
 
 (! $help)or die <<USAGE;
 Usage: $0 [options]
@@ -39,6 +42,9 @@ Downloads all the MLST databases to disk
 
 # download everything with defaults
 download_mlst_databases
+
+# print version information
+download_mlst_databases -v
 
 # Pass in a different url to download
 download_mlst_databases -u http://example.com/myfasta.fa

--- a/bin/download_fasta_database
+++ b/bin/download_fasta_database
@@ -7,15 +7,21 @@ package Bio::MLST::Bin::Download;
 
 Downloads all the MLST databases to disk. It requires access to the Internet.
 
-   # download everything with defaults
-   download_mlst_databases
+    # download everything with defaults
+    download_mlst_databases
+
+    # print version information
+    download_mlst_databases -v
+
+    # XML file containing details of the MLST databases (from pubmlst)
+    download_mlst_databases -c my_config_file.json
  
-   # XML file containing details of the MLST databases (from pubmlst)
-   download_mlst_databases -c my_config_file.json
- 
-   # destination base directory defaults to the environment variable \$MLST_DATABASES
-   download_mlst_databases -b /path/to/destination
-   
+    # Pass in a different url to download
+    download_mlst_databases -u http://example.com/myfasta.fa
+
+    # destination base directory defaults to the environment variable \$MLST_DATABASES
+    download_mlst_databases -b /path/to/destination
+
 =cut
 
 BEGIN { unshift( @INC, '../lib' ) }
@@ -45,6 +51,9 @@ download_mlst_databases
 
 # print version information
 download_mlst_databases -v
+
+# XML file containing details of the MLST databases (from pubmlst)
+download_mlst_databases -c my_config_file.json
 
 # Pass in a different url to download
 download_mlst_databases -u http://example.com/myfasta.fa

--- a/bin/download_mlst_databases
+++ b/bin/download_mlst_databases
@@ -7,15 +7,18 @@ package Bio::MLST::Bin::Download;
 
 Downloads all the MLST databases to disk. It requires access to the Internet.
 
-   # download everything with defaults
-   download_mlst_databases
- 
-   # XML file containing details of the MLST databases (from pubmlst)
-   download_mlst_databases -c my_config_file.json
- 
-   # destination base directory defaults to the environment variable \$MLST_DATABASES
-   download_mlst_databases -b /path/to/destination
-   
+    # download everything with defaults
+    download_mlst_databases
+
+    # print version
+    download_mlst_databases -v
+
+    # XML file containing details of the MLST databases (from pubmlst)
+    download_mlst_databases -c my_config_file.json
+
+    # destination base directory defaults to the environment variable \$MLST_DATABASES
+    download_mlst_databases -b /path/to/destination
+
 =cut
 
 BEGIN { unshift( @INC, '../lib' ) }

--- a/bin/download_mlst_databases
+++ b/bin/download_mlst_databases
@@ -25,12 +25,15 @@ use Getopt::Long;
 use Bio::MLST::DatabaseSettings;
 use Bio::MLST::Download::Databases;
 
-my ($config_file, $base_directory, $help);
+my ($config_file, $base_directory, $help, $version);
 
 GetOptions ('c|config=s'         => \$config_file,
             'b|base_directory=s' => \$base_directory,
             'h|help'             => \$help,
+            'v|version'          => \$version,
 );
+
+(! $version ) or die "$0 version " . Bio::MLST::Bin::Download->VERSION . "\n";
 
 (! $help)or die <<USAGE;
 Usage: $0 [options]
@@ -38,6 +41,9 @@ Downloads all the MLST databases to disk
 
 # download everything with defaults
 download_mlst_databases
+
+# print version
+download_mlst_databases -v
 
 # XML file containing details of the MLST databases (from pubmlst)
 download_mlst_databases -c my_config_file.json

--- a/bin/get_emm_sequence_type
+++ b/bin/get_emm_sequence_type
@@ -9,34 +9,29 @@ Given Fasta files and a Species regex, lookup the relevant MLST database and out
 It requires NBCI Blast+ to be available in your PATH.
 
    # Basic usage, sequence type result written to my_assembly.fa.st
-   get_emm_sequence_type -s "Streptococcus pyogenes" my_assembly.fa
-   
-   # Multiple fasta files 
-   get_emm_sequence_type -s "Streptococcus pyogenes" myfasta.fa anotherfasta.fa yetanother.fa
-   # or
-   get_emm_sequence_type -s "Streptococcus pyogenes" *.fa
-   
-   # Split into 8 parallel processes (much faster), default is 2
-   get_emm_sequence_type -s "Streptococcus pyogenes" -d 8 *.fa
-   
-   # output a fasta file with the concatenated alleles and unknown sequences
-   get_emm_sequence_type -s "Streptococcus pyogenes" -c  my_assembly.fa 
-   
-   # Specify an output directory 
-   get_emm_sequence_type  -s "Streptococcus pyogenes" -o /path/to/results my_assembly.fa
-   
-   # Match against multiple MLST databases
-   get_emm_sequence_type -s "Clostridium botulinum, Streptococcus pyogenes" my_assembly.fa
-   
-   # Match against all MLST databases
    get_emm_sequence_type my_assembly.fa
-   
-   # list all available MLST databases
-   get_emm_sequence_type -a
-   
+
+   # Multiple fasta files
+   get_emm_sequence_type myfasta.fa anotherfasta.fa yetanother.fa
+
+   # Split into 8 parallel processes (much faster), default is 2
+   get_emm_sequence_type -d 8 *.fa
+
+   # output a fasta file with the concatenated alleles and unknown sequences
+   get_emm_sequence_type -c  my_assembly.fa
+
+   # output a phylip file with the concatenated alleles and unknown sequences
+   get_emm_sequence_type -y  my_assembly.fa
+
+   # Specify an output directory
+   get_emm_sequence_type  -o /path/to/results my_assembly.fa
+
    # This help message
    get_emm_sequence_type -h
-   
+
+   # print version
+   get_emm_sequence_type -v
+
 =cut
 
 

--- a/bin/get_emm_sequence_type
+++ b/bin/get_emm_sequence_type
@@ -70,19 +70,19 @@ Usage: $0 [options]
 # Basic usage, sequence type result written to my_assembly.fa.st
 get_emm_sequence_type my_assembly.fa
 
-# Multiple fasta files 
+# Multiple fasta files
 get_emm_sequence_type myfasta.fa anotherfasta.fa yetanother.fa
 
 # Split into 8 parallel processes (much faster), default is 2
 get_emm_sequence_type -d 8 *.fa
 
 # output a fasta file with the concatenated alleles and unknown sequences
-get_emm_sequence_type -c  my_assembly.fa 
+get_emm_sequence_type -c  my_assembly.fa
 
 # output a phylip file with the concatenated alleles and unknown sequences
 get_emm_sequence_type -y  my_assembly.fa
 
-# Specify an output directory 
+# Specify an output directory
 get_emm_sequence_type  -o /path/to/results my_assembly.fa
 
 # This help message

--- a/bin/get_emm_sequence_type
+++ b/bin/get_emm_sequence_type
@@ -51,7 +51,7 @@ use Bio::MLST::Validate::Executable;
 use Bio::MLST::SearchForFiles;
 use Bio::MLST::CheckMultipleSpecies;
 
-my ($species, $output_fasta_files, $output_directory, $output_phylip_files, $available_databases, $base_directory, $makeblastdb_exec, $blastn_exec, $spreadsheet_basename,$parallel_processes, $help);
+my ($species, $output_fasta_files, $output_directory, $output_phylip_files, $available_databases, $base_directory, $makeblastdb_exec, $blastn_exec, $spreadsheet_basename,$parallel_processes, $help, $version);
 
 GetOptions ('s|species=s'              => \$species,
             'o|output_directory=s'     => \$output_directory,
@@ -64,7 +64,10 @@ GetOptions ('s|species=s'              => \$species,
             'p|spreadsheet_basename=s' => \$spreadsheet_basename,
             'd|parallel_processes=i'   => \$parallel_processes,
             'h|help'                   => \$help,
+            'v|version'                => \$version,
 );
+
+(! $version ) or die "$0 version " . Bio::MLST::Bin::GetEmmSequenceType->VERSION . "\n";
 
 ( ((@ARGV > 0) || (defined($available_databases))) && ! $help ) or die <<USAGE;
 Usage: $0 [options]
@@ -89,6 +92,9 @@ get_emm_sequence_type  -o /path/to/results my_assembly.fa
 
 # This help message
 get_emm_sequence_type -h
+
+# print version
+get_emm_sequence_type -v
 
 USAGE
 ;

--- a/bin/get_sequence_type
+++ b/bin/get_sequence_type
@@ -51,7 +51,7 @@ use Bio::MLST::Validate::Executable;
 use Bio::MLST::SearchForFiles;
 use Bio::MLST::CheckMultipleSpecies;
 
-my ($species, $output_fasta_files, $output_directory, $show_alternatives, $output_phylip_files, $available_databases, $base_directory, $makeblastdb_exec, $blastn_exec, $spreadsheet_basename,$parallel_processes, $report_lowest_st, $help);
+my ($species, $output_fasta_files, $output_directory, $show_alternatives, $output_phylip_files, $available_databases, $base_directory, $makeblastdb_exec, $blastn_exec, $spreadsheet_basename,$parallel_processes, $report_lowest_st, $help, $version);
 
 GetOptions ('s|species=s'              => \$species,
             'o|output_directory=s'     => \$output_directory,
@@ -66,7 +66,10 @@ GetOptions ('s|species=s'              => \$species,
             'show_alternatives'        => \$show_alternatives,
             'report_lowest_st'         => \$report_lowest_st,
             'h|help'                   => \$help,
+            'v|version'                => \$version,
 );
+
+(! $version ) or die "$0 version " . Bio::MLST::Bin::GetSequenceType->VERSION . "\n";
 
 ( ((@ARGV > 0) || (defined($available_databases))) && ! $help ) or die <<USAGE;
 Usage: $0 [options]
@@ -102,6 +105,9 @@ get_sequence_type -a
 
 # This help message
 get_sequence_type -h
+
+# print version
+get_sequence_type -v
 
 USAGE
 ;

--- a/bin/get_sequence_type
+++ b/bin/get_sequence_type
@@ -20,9 +20,12 @@ It requires NBCI Blast+ to be available in your PATH.
    get_sequence_type -s "Clostridium difficile" -d 8 *.fa
    
    # output a fasta file with the concatenated alleles and unknown sequences
-   get_sequence_type -s "Clostridium difficile" -c  my_assembly.fa 
-   
-   # Specify an output directory 
+   get_sequence_type -s "Clostridium difficile" -c  my_assembly.fa
+
+   # output a phylip file with the concatenated alleles and unknown sequences
+   get_sequence_type -s "Clostridium difficile" -y  my_assembly.fa
+
+   # Specify an output directory
    get_sequence_type  -s "Clostridium difficile" -o /path/to/results my_assembly.fa
    
    # Match against multiple MLST databases
@@ -36,7 +39,10 @@ It requires NBCI Blast+ to be available in your PATH.
    
    # This help message
    get_sequence_type -h
-   
+
+   # print version
+   get_sequence_type -v
+
 =cut
 
 

--- a/bin/get_sequence_type
+++ b/bin/get_sequence_type
@@ -10,15 +10,15 @@ It requires NBCI Blast+ to be available in your PATH.
 
    # Basic usage, sequence type result written to my_assembly.fa.st
    get_sequence_type -s "Clostridium difficile" my_assembly.fa
-   
-   # Multiple fasta files 
+
+   # Multiple fasta files
    get_sequence_type -s "Clostridium difficile" myfasta.fa anotherfasta.fa yetanother.fa
    # or
    get_sequence_type -s "Clostridium difficile" *.fa
-   
+
    # Split into 8 parallel processes (much faster), default is 2
    get_sequence_type -s "Clostridium difficile" -d 8 *.fa
-   
+
    # output a fasta file with the concatenated alleles and unknown sequences
    get_sequence_type -s "Clostridium difficile" -c  my_assembly.fa
 
@@ -27,16 +27,16 @@ It requires NBCI Blast+ to be available in your PATH.
 
    # Specify an output directory
    get_sequence_type  -s "Clostridium difficile" -o /path/to/results my_assembly.fa
-   
+
    # Match against multiple MLST databases
    get_sequence_type -s "Clostridium botulinum, Clostridium difficile" my_assembly.fa
-   
+
    # Match against all MLST databases
    get_sequence_type my_assembly.fa
-   
+
    # list all available MLST databases
    get_sequence_type -a
-   
+
    # This help message
    get_sequence_type -h
 
@@ -83,7 +83,7 @@ Usage: $0 [options]
 # Basic usage, sequence type result written to my_assembly.fa.st
 get_sequence_type -s "Clostridium difficile" my_assembly.fa
 
-# Multiple fasta files 
+# Multiple fasta files
 get_sequence_type -s "Clostridium difficile" myfasta.fa anotherfasta.fa yetanother.fa
 # or
 get_sequence_type -s "Clostridium difficile" *.fa
@@ -92,12 +92,12 @@ get_sequence_type -s "Clostridium difficile" *.fa
 get_sequence_type -s "Clostridium difficile" -d 8 *.fa
 
 # output a fasta file with the concatenated alleles and unknown sequences
-get_sequence_type -s "Clostridium difficile" -c  my_assembly.fa 
+get_sequence_type -s "Clostridium difficile" -c  my_assembly.fa
 
 # output a phylip file with the concatenated alleles and unknown sequences
 get_sequence_type -s "Clostridium difficile" -y  my_assembly.fa
 
-# Specify an output directory 
+# Specify an output directory
 get_sequence_type  -s "Clostridium difficile" -o /path/to/results my_assembly.fa
 
 # Match against multiple MLST databases

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,8 @@ requires = makeblastdb
 [ExtraTests]
 [AutoPrereqs]
 [AutoVersion]
+major = 2
+format = {{ $major }}.0.{{ cldr('yyDDDHH') }} ; you can update the minor version here
 [PodWeaver]
 format = {{ cldr('yyyyMMdd') }}.{{ cldr('HHmm') }}
 

--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ requires = makeblastdb
 [AutoVersion]
 major = 2
 format = {{ $major }}.0.{{ cldr('yyDDDHH') }} ; you can update the minor version here
+[PkgVersion]
 [PodWeaver]
 format = {{ cldr('yyyyMMdd') }}.{{ cldr('HHmm') }}
 


### PR DESCRIPTION
Bumps the version to 2.0.xxx

I've changed to use semantic versioning: http://semver.org/

The version now automatically increments the patch version with YYdddHH (e.g. 1510610 => its 2015, today is the 106th day, and it's about 10 o'clock) so the version will be 2.0.1510610

You can update the major and minor versions in dist.ini

I've also added a plugin which adds a VERSION variable to all packages at release time and added a --version argument to all scripts which reports the currently installed version.