### PR TITLE
Ignore metadata column headings in profiles

### DIFF
--- a/lib/Bio/MLST/Check.pm
+++ b/lib/Bio/MLST/Check.pm
@@ -142,7 +142,7 @@ sub _build__input_fasta_files
 sub create_result_files
 {
   my($self) = @_;
-  exit unless $self->input_fasta_files_exist;
+  exit 1 unless $self->input_fasta_files_exist;
   $self->_generate_spreadsheet_rows;
 
   my $spreadsheet = Bio::MLST::Spreadsheet::File->new(

--- a/lib/Bio/MLST/CheckMultipleSpecies.pm
+++ b/lib/Bio/MLST/CheckMultipleSpecies.pm
@@ -262,8 +262,8 @@ sub create_result_files
 {
     my($self) = @_;
 
-    exit unless $self->_check_input_files_exist;
-    exit unless $self->_check_fasta_phylip_options;
+    exit 1 unless $self->_check_input_files_exist;
+    exit 1 unless $self->_check_fasta_phylip_options;
     $self->_run_mlst_for_species_list();
     $self->_concatenate_result_files();
 

--- a/lib/Bio/MLST/FilterAlleles.pm
+++ b/lib/Bio/MLST/FilterAlleles.pm
@@ -21,12 +21,12 @@ our @EXPORT_OK = qw(only_keep_alleles is_metadata);
 # contents of the alleles directory or from the
 # config file downloaded from the internet.
 my @allele_blacklist = (
-#  'CC',
-#  'Lineage',
+  'CC',
+  'Lineage',
   'ST',
   'clonal_complex',
   'mlst_clade',
-#  'species'
+  'species'
 );
 
 sub is_metadata

--- a/lib/Bio/MLST/FilterAlleles.pm
+++ b/lib/Bio/MLST/FilterAlleles.pm
@@ -1,0 +1,36 @@
+=head NAME
+
+FilterAlleles.pm - Filter header row  from profile to remove non-alleles
+
+=head 1 SYNOPSIS
+
+=cut
+
+package Bio::MLST::FilterAlleles;
+
+use strict;
+use warnings;
+
+use Exporter qw(import);
+our @EXPORT_OK = qw(only_keep_alleles);
+
+my @allele_blacklist = (
+#  'CC',
+#  'Lineage',
+  'ST',
+  'clonal_complex',
+  'mlst_clade',
+#  'species'
+);
+
+sub only_keep_alleles
+{
+  my ($alleles) = @_;
+  my @alleles_to_keep = ();
+  for my $allele (@$alleles) {
+    push( @alleles_to_keep, $allele ) unless ($allele ~~ @allele_blacklist);
+  }
+  return \@alleles_to_keep;
+}
+
+1;

--- a/lib/Bio/MLST/FilterAlleles.pm
+++ b/lib/Bio/MLST/FilterAlleles.pm
@@ -12,8 +12,14 @@ use strict;
 use warnings;
 
 use Exporter qw(import);
-our @EXPORT_OK = qw(only_keep_alleles);
+our @EXPORT_OK = qw(only_keep_alleles is_metadata);
 
+# A list of column headings in a profile file which
+# can be assumed not to be allele names.  If this list
+# gets much longer we should have a rethink about
+# getting a whitelist of alleles either based on the
+# contents of the alleles directory or from the
+# config file downloaded from the internet.
 my @allele_blacklist = (
 #  'CC',
 #  'Lineage',
@@ -23,12 +29,18 @@ my @allele_blacklist = (
 #  'species'
 );
 
+sub is_metadata
+{
+  my ($column_heading) = @_;
+  return $column_heading ~~ @allele_blacklist;
+}
+
 sub only_keep_alleles
 {
   my ($alleles) = @_;
   my @alleles_to_keep = ();
   for my $allele (@$alleles) {
-    push( @alleles_to_keep, $allele ) unless ($allele ~~ @allele_blacklist);
+    push( @alleles_to_keep, $allele ) unless is_metadata($allele);
   }
   return \@alleles_to_keep;
 }

--- a/lib/Bio/MLST/SequenceType.pm
+++ b/lib/Bio/MLST/SequenceType.pm
@@ -33,6 +33,7 @@ use List::Util qw(min reduce);
 
 use Moose;
 use Bio::MLST::Types;
+use Bio::MLST::FilterAlleles qw(is_metadata);
 
 has 'profiles_filename'     => ( is => 'ro', isa => 'Bio::MLST::File',        required => 1 );
 has 'matching_names'        => ( is => 'ro', isa => 'ArrayRef',   required => 1 );
@@ -113,8 +114,7 @@ sub _build_sequence_type
 
   for(my $i=0; $i< @header_row; $i++)
   {
-    next if($header_row[$i] eq "clonal_complex");
-    next if($header_row[$i] eq "mlst_clade");
+    next if(is_metadata($header_row[$i]));
     $header_row[$i] =~ s!_!!g;
     $header_row[$i] =~ s!-!!g;
   }
@@ -128,7 +128,7 @@ sub _build_sequence_type
     my @current_row = @{$self->_profiles->[$row]};
     for(my $col = 0; $col< @current_row; $col++)
     {
-      next if($header_row[$col] eq "ST" || $header_row[$col] eq "clonal_complex" || $header_row[$col] eq "mlst_clade");
+      next if(is_metadata($header_row[$col]));
       $num_loci++ if($row == 1);
 
       my $allele_number = $self->allele_to_number->{$header_row[$col]};

--- a/lib/Bio/MLST/Spreadsheet/Row.pm
+++ b/lib/Bio/MLST/Spreadsheet/Row.pm
@@ -32,6 +32,8 @@ Returns the spreadsheet row of results containing the genomic sequences of the m
 use Data::Dumper;
 use Text::CSV;
 
+use Bio::MLST::FilterAlleles qw(only_keep_alleles);
+
 use Moose;
 
 has 'sequence_type_obj'  => ( is => 'ro', isa => 'Bio::MLST::SequenceType',     required => 1 ); 
@@ -91,8 +93,7 @@ sub _build__allele_order {
   open( my $profile_fh, '<', $profile_path );
 
   my @alleles = @{$csv->getline($profile_fh)};
-  @alleles = grep { $_ ne 'ST' } @alleles;
-  @alleles = grep { $_ ne 'clonal_complex' } @alleles;
+  @alleles = @{only_keep_alleles(\@alleles)};
 
   my @fixed_alleles;
   foreach my $allele ( @alleles ){

--- a/t/FilterAlleles.t
+++ b/t/FilterAlleles.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+BEGIN { unshift(@INC, './lib') }
+BEGIN {
+    use Test::Most;
+    use_ok('Bio::MLST::FilterAlleles', qw(only_keep_alleles));
+}
+
+use Bio::MLST::FilterAlleles qw(only_keep_alleles);
+
+my $potential_alleles = ['abc', 'def'];
+my $expected_alleles = ['abc', 'def'];
+
+is_deeply(only_keep_alleles($potential_alleles), $expected_alleles, "They were all alleles");
+
+$potential_alleles = ['abc', 'def', 'clonal_complex'];
+$expected_alleles = ['abc', 'def'];
+
+is_deeply(only_keep_alleles($potential_alleles), $expected_alleles, "There is a clonal_complex");
+
+done_testing();
+

--- a/t/data/databases/Escherichia_coli_1/profiles/escherichia_coli.txt
+++ b/t/data/databases/Escherichia_coli_1/profiles/escherichia_coli.txt
@@ -1,6 +1,6 @@
-ST	adk	purA	recA	clonal_complex
+ST	adk	purA	recA	clonal_complex	Lineage
 1	2	3	4	ST20 Cplx
-2	1	2	3
-3	1	1	1
+2	1	2	3		foo
+3	1	1	1	bar	baz
 4	2	3	1
 5	1	1	1


### PR DESCRIPTION
Addresses ticket 488940

Sometimes profiles have additional metadata columns such as clonal_complex.  This PR splits out the checks for such columns into a reusable function and adds a list which is more easily updated as more become apparent.

Metadata seems to be a little inconsistent; if we keep adding much more then we should consider whitelisting alleles instead based either on the files in the alleles directory of the database or based on the config file used to download the database in the first instance.