### PR TITLE
BUG: missing semicolon in get_emm_sequence_type script

### DIFF
--- a/bin/get_emm_sequence_type
+++ b/bin/get_emm_sequence_type
@@ -99,7 +99,7 @@ $base_directory ||= '/lustre/scratch108/pathogen/pathpipe/mlst';
 
 # Multiple versions of blast lying around, so use a particular one if possible
 # Warns if the user's preferred executable cannot be found; errors if defaults are also missing
-my $validator = Bio::MLST::Validate::Executable->new()
+my $validator = Bio::MLST::Validate::Executable->new();
 $makeblastdb_exec = $validator->preferred_executable($makeblastdb_exec,
                                                      ['/software/pubseq/bin/ncbi-blast-2.2.28+/bin/makeblastdb',
                                                       'makeblastdb']);


### PR DESCRIPTION
Looks to be the same bug reported in commit #57 but in the sister script.